### PR TITLE
README.md: include python3 in install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First build and install.
 
     apt-get install cmake build-essential libboost-regex-dev \
             libboost-filesystem-dev libboost-program-options-dev \
-            libboost-system-dev libreadline-dev
+            libboost-system-dev libreadline-dev python3
     mkdir build && cd build
     cmake ..
     make


### PR DESCRIPTION
I noticed python3 was not installed on our machine, thus yielding

```
# update-xennigan 
/usr/bin/env: python3: No such file or directory
```

This commit adds `python3` in the `apt-get install` command.
